### PR TITLE
impr(handle-null-job): ignore not found jobs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,8 @@ services:
       - 3002:9090
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
   redis:
     image: redis:alpine
     ports:

--- a/src/bull/bullmq-metrics.factory.ts
+++ b/src/bull/bullmq-metrics.factory.ts
@@ -203,6 +203,7 @@ export class BullMQMetricsFactory {
 
     queueEvents.on('stalled', async (event) => {
       const job = await queue.getJob(event.jobId);
+      if (!job) { return; }
       const jobLabels = {
         [LABEL_NAMES.JOB_NAME]: job.name,
         ...labels,
@@ -211,6 +212,7 @@ export class BullMQMetricsFactory {
     });
     queueEvents.on('active', async (event) => {
       const job = await queue.getJob(event.jobId);
+      if (!job) { return; }
       const jobLabels = {
         [LABEL_NAMES.JOB_NAME]: job.name,
         ...labels,
@@ -219,6 +221,7 @@ export class BullMQMetricsFactory {
     });
     queueEvents.on('waiting', async (event) => {
       const job = await queue.getJob(event.jobId);
+      if (!job) { return; }
       const jobLabels = {
         [LABEL_NAMES.JOB_NAME]: job.name,
         ...labels,
@@ -227,6 +230,7 @@ export class BullMQMetricsFactory {
     });
     queueEvents.on('failed', async (event) => {
       const job = await queue.getJob(event.jobId);
+      if (!job) { return; }
       const errorType = job.stacktrace[job.stacktrace.length - 1]?.match(
         /^(?<errorType>[^:]+):/,
       )?.groups?.errorType;
@@ -240,6 +244,7 @@ export class BullMQMetricsFactory {
     });
     queueEvents.on('delayed', async (event) => {
       const job = await queue.getJob(event.jobId);
+      if (!job) { return; }
       const jobLabels = {
         [LABEL_NAMES.JOB_NAME]: job.name,
         ...labels,
@@ -248,6 +253,7 @@ export class BullMQMetricsFactory {
     });
     queueEvents.on('completed', async (event) => {
       const job = await queue.getJob(event.jobId);
+      if (!job) { return; }
       const jobLabels = {
         [LABEL_NAMES.JOB_NAME]: job.name,
         ...labels,


### PR DESCRIPTION
Fix this bug:

```
TypeError
TypeError: Cannot read properties of undefined (reading 'name')
    at QueueEvents.<anonymous> (/src/bull/bullmq-metrics.factory.ts:252:37)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

IDK why a completed job can't be found, but it makes sense to me to add this safe guard.